### PR TITLE
Added options for adding timezone

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,16 +1,16 @@
 
-# metalsmith-build-date
+# metalsmith-build-date-tz
 
   A Metalsmith plugin that adds a build date to the metadata. Useful for `atom.xml` or other feeds.
 
 ## Installation
 
-    $ npm install metalsmith-build-date
+    $ npm install https://github.com/brianfidler/metalsmith-build-date-tz.git
 
 ## Usage
 
 ```js
-var date = require('metalsmith-build-date');
+var date = require('metalsmith-build-date-tz');
 
 metalsmith.use(date());
 ```
@@ -39,12 +39,12 @@ metalsmith.use(date({ key: 'dateBuilt' ));
 
 ## CLI Usage
 
-  Install via npm and then add the `metalsmith-build-date` key to your `metalsmith.json`:
+  Install via npm and then add the `metalsmith-build-date-tz` key to your `metalsmith.json`:
 
 ```json
 {
   "plugins": {
-    "metalsmith-build-date": true
+    "metalsmith-build-date-tz": true
   }
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,17 @@ function plugin(options) {
 
   return function(files, metalsmith, done){
     var data = metalsmith.metadata();
-    data[options.key] = new Date();
+    
+    today = new Date();
+    
+    //modified date to display EST
+    options.timeZone = 'America/New_York';
+    options.timeZoneName = 'short';
+    today.setHours(today.getHours());
+    today = today.toLocaleString('en-US', options);
+    //
+
+    data[options.key] = today;
     done();
   };
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,6 @@ function plugin(options) {
     //modified date to display EST
     options.timeZone = 'America/New_York';
     options.timeZoneName = 'short';
-    today.setHours(today.getHours());
     today = today.toLocaleString('en-US', options);
     //
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metalsmith-build-date",
-  "description": "A Metalsmith plugin that adds a build date to the metadata.",
-  "repository": "git://github.com/segmentio/metalsmith-build-date.git",
+  "description": "A Metalsmith plugin that adds a build date to the metadata, and also allows timezone to be added.",
+  "repository": "git://github.com/brianfidler/metalsmith-build-date.git",
   "version": "0.2.0",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metalsmith-build-date",
   "description": "A Metalsmith plugin that adds a build date to the metadata, and also allows timezone to be added.",
-  "repository": "git://github.com/brianfidler/metalsmith-build-date.git",
+  "repository": "git://github.com/brianfidler/metalsmith-build-date-tz.git",
   "version": "0.2.0",
   "license": "MIT",
   "main": "lib/index.js",


### PR DESCRIPTION
Added two options to index.js, one for timezone and one for timezone name. This allows users to choose the timezone they want the build date/time to display in. 